### PR TITLE
Validate setup requires root execution

### DIFF
--- a/validate-setup.sh
+++ b/validate-setup.sh
@@ -347,6 +347,11 @@ main() {
     echo "   ZFS + ZFSBootMenu Setup Validator"
     echo "═══════════════════════════════════════"
 
+    if [[ $EUID -ne 0 ]]; then
+        printf "${RED}✗ This script must be run as root (use sudo)${NC}\n" >&2
+        exit 1
+    fi
+
     header "Core System"
     ROOT_DATASET=$(check_root_on_zfs)
     check_boot_directory


### PR DESCRIPTION
## Summary
- Require `validate-setup.sh` to run as root and exit with an error if not

## Testing
- `./validate-setup.sh` *(fails: Root is not on ZFS)*
- `sudo -u nobody ./validate-setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a37350c4308323883533c0d7f0b1b4