### PR TITLE
Fix BE unbound variable in prune hook

### DIFF
--- a/system-scripts/hooks-common.sh
+++ b/system-scripts/hooks-common.sh
@@ -79,13 +79,14 @@ EOF
 
 install_prune_snapshots_hook() {
     install -d /usr/local/sbin /etc/pacman.d/hooks
+    local BE_EXPR='${BE}'
     cat >/usr/local/sbin/zfs-prune-pacman-snapshots.sh <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 KEEP=\${KEEP:-${SNAPSHOT_KEEP}}
 BE="\$(findmnt -no SOURCE /)"
 [[ -z "\$BE" ]] && exit 1
-mapfile -t snaps < <(zfs list -H -t snapshot -o name -s creation | grep "^\\${BE}@pacman-")
+mapfile -t snaps < <(zfs list -H -t snapshot -o name -s creation | grep "^${BE_EXPR}@pacman-")
 if (( \${#snaps[@]} > KEEP )); then
     del_count=\$(( \${#snaps[@]} - KEEP ))
     printf "%s\n" "\${snaps[@]:0:del_count}" | xargs -r -n1 zfs destroy


### PR DESCRIPTION
## Summary
- prevent BE variable expansion when generating prune snapshot hook
- ensure pacman hook script retains literal `${BE}` pattern

## Testing
- `bash -n system-scripts/hooks-common.sh`
- `./validate-setup.sh` *(fails: Root is not on ZFS)*

------
https://chatgpt.com/codex/tasks/task_e_68a37485024c83238fe707b6aabb3c8f