### PR TITLE
Clean pacman lock in cloned boot environments

### DIFF
--- a/fish-shell/functions/zfs-be-clone.fish
+++ b/fish-shell/functions/zfs-be-clone.fish
@@ -59,6 +59,15 @@ function zfs-be-clone --description 'Clone snapshot to boot environment'
         return 1
     end
 
+    # Remove pacman database lock from new BE
+    set -l mnt (mktemp -d)
+    if sudo mount -t zfs $be_root $mnt
+        sudo rm -f $mnt/var/lib/pacman/db.lck
+        sudo umount $mnt
+    end
+    rmdir $mnt
+
+
     # Set ZBM properties
     set -l zbm_cmd "sudo zfs set org.zfsbootmenu:commandline=\"rw quiet\" $be_root"
     if not set -q _flag_quiet

--- a/fish-shell/functions/zfs-snapshot-clone.fish
+++ b/fish-shell/functions/zfs-snapshot-clone.fish
@@ -42,6 +42,13 @@ function zfs-snapshot-clone --description 'Clone ZFS snapshot to new dataset'
 
     eval $cmd
     if test $status -eq 0
+        set -l mnt (mktemp -d)
+        if sudo mount -t zfs $clone_name $mnt
+            sudo rm -f $mnt/var/lib/pacman/db.lck
+            sudo umount $mnt
+        end
+        rmdir $mnt
+
         echo "Cloned $snapshot to $clone_name"
     end
 end


### PR DESCRIPTION
## Summary
- remove global tmpfiles rule for pacman lock cleanup
- strip pacman lock feature from documentation and installer
- purge pacman db.lck in new ZFS clones

## Testing
- `bash -n install.sh`
- `fish -n fish-shell/functions/zfs-be-clone.fish` *(fails: command not found)*
- `fish -n fish-shell/functions/zfs-snapshot-clone.fish` *(fails: command not found)*
- `shellcheck install.sh` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a39e501d7883238090698626997c3f