### PR TITLE
Use zfs mount for temporary dataset mounts

### DIFF
--- a/fish-shell/functions/zfs-be-clone.fish
+++ b/fish-shell/functions/zfs-be-clone.fish
@@ -61,10 +61,13 @@ function zfs-be-clone --description 'Clone snapshot to boot environment'
 
     # Remove pacman database lock from new BE
     set -l mnt (mktemp -d)
-    if sudo mount -t zfs $be_root $mnt
+    set -l orig_mountpoint (zfs get -H -o value mountpoint $be_root)
+    sudo zfs set mountpoint=$mnt $be_root
+    if sudo zfs mount $be_root
         sudo rm -f $mnt/var/lib/pacman/db.lck
-        sudo umount $mnt
+        sudo zfs umount $be_root
     end
+    sudo zfs set mountpoint=$orig_mountpoint $be_root
     rmdir $mnt
 
 

--- a/fish-shell/functions/zfs-be-test-clone.fish
+++ b/fish-shell/functions/zfs-be-test-clone.fish
@@ -38,12 +38,16 @@ function zfs-be-test-clone --description 'Create test boot environment from late
     end
 
     if test $status -eq 0
-	set -l mnt (mktemp -d)
-        if sudo mount -t zfs $clone_name $mnt
+        set -l be_root "$ZFS_BE_ROOT/$test_name/root"
+        set -l mnt (mktemp -d)
+        set -l orig_mountpoint (zfs get -H -o value mountpoint $be_root)
+        sudo zfs set mountpoint=$mnt $be_root
+        if sudo zfs mount $be_root
             sudo rm -f $mnt/var/lib/pacman/db.lck
-            sudo umount $mnt
+            sudo zfs umount $be_root
         end
-        rmdir $mnt   
+        sudo zfs set mountpoint=$orig_mountpoint $be_root
+        rmdir $mnt
         echo "Test BE created: $test_name"
         echo "To clean up later: sudo zfs destroy -r $ZFS_BE_ROOT/$test_name"
     end

--- a/fish-shell/functions/zfs-snapshot-clone.fish
+++ b/fish-shell/functions/zfs-snapshot-clone.fish
@@ -43,10 +43,13 @@ function zfs-snapshot-clone --description 'Clone ZFS snapshot to new dataset'
     eval $cmd
     if test $status -eq 0
         set -l mnt (mktemp -d)
-        if sudo mount -t zfs $clone_name $mnt
+        set -l orig_mountpoint (zfs get -H -o value mountpoint $clone_name)
+        sudo zfs set mountpoint=$mnt $clone_name
+        if sudo zfs mount $clone_name
             sudo rm -f $mnt/var/lib/pacman/db.lck
-            sudo umount $mnt
+            sudo zfs umount $clone_name
         end
+        sudo zfs set mountpoint=$orig_mountpoint $clone_name
         rmdir $mnt
 
         echo "Cloned $snapshot to $clone_name"


### PR DESCRIPTION
## Summary
- replace legacy `mount -t zfs` calls with `zfs mount` and `zfs set mountpoint` handling in cloning helpers

## Testing
- `fish -n fish-shell/functions/zfs-be-clone.fish` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ae5642408323a7075e7454bb3cf7