### PR TITLE
Add all-in-one installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Opinionated ZFS setup for CachyOS providing ZFSBootMenu boot environments, autom
 - `/boot` is a directory inside each boot environment dataset
 
 ## Quick start
+Run everything in one shot (replace `/dev/nvme0n1p1` with your ESP device):
+```bash
+curl -fsSL https://raw.githubusercontent.com/CachyOS/cachyos-zfs-setup/main/all-in-one.sh | sudo bash -s -- /dev/nvme0n1p1
+```
+The script clones this repository, installs helpers, configures ZFSBootMenu and runs validation. If the ESP device looks suspicious, it will warn before proceeding.
+
+### Manual steps
 ```bash
 git clone https://github.com/polkamaphone/cachyos-zfs-setup.git
 cd cachyos-zfs-setup

--- a/all-in-one.sh
+++ b/all-in-one.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# all-in-one.sh - bootstrap CachyOS ZFS setup
+#
+# Fetches the repository, runs install.sh, zbm-setup.sh, and validate-setup.sh
+# sequentially. Intended for usage via:
+#   curl -fsSL https://raw.githubusercontent.com/<owner>/cachyos-zfs-setup/main/all-in-one.sh | sudo bash -s -- [ESP_DEVICE]
+#
+# Environment variables:
+#   REPO_URL  - Git repository to clone (default: https://github.com/CachyOS/cachyos-zfs-setup.git)
+#   BRANCH    - Branch to checkout (default: main)
+#   WORKDIR   - Directory to clone into (default: /tmp/cachyos-zfs-setup)
+
+set -euo pipefail
+
+REPO_URL="${REPO_URL:-https://github.com/CachyOS/cachyos-zfs-setup.git}"
+BRANCH="${BRANCH:-main}"
+WORKDIR="${WORKDIR:-/tmp/cachyos-zfs-setup}"
+
+# Fresh clone
+rm -rf "$WORKDIR"
+git clone --depth 1 --branch "$BRANCH" "$REPO_URL" "$WORKDIR"
+cd "$WORKDIR"
+
+# Warn if ESP argument looks suspicious
+./esp-validate "$@"
+
+# Run main installation
+./install.sh
+
+# Run ZFSBootMenu setup, forwarding any user arguments (e.g., ESP device)
+./system-scripts/zbm-setup.sh "$@"
+
+# Validate final setup
+./validate-setup.sh

--- a/esp-validate
+++ b/esp-validate
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# esp-validate - basic sanity checks for ESP device input
+# Usage: esp-validate [/dev/sdXn]
+
+set -euo pipefail
+
+ESP_DEV="${1:-}"
+
+if [[ -z "$ESP_DEV" ]]; then
+  echo "[esp-validate] No ESP device specified; skipping validation" >&2
+  exit 0
+fi
+
+if [[ ! -e "$ESP_DEV" ]]; then
+  echo "[esp-validate] WARNING: $ESP_DEV does not exist" >&2
+  exit 0
+fi
+
+if [[ ! -b "$ESP_DEV" ]]; then
+  echo "[esp-validate] WARNING: $ESP_DEV is not a block device" >&2
+  exit 0
+fi
+
+fstype=$(lsblk -no FSTYPE "$ESP_DEV" 2>/dev/null || true)
+partlabel=$(lsblk -no PARTLABEL "$ESP_DEV" 2>/dev/null || true)
+if [[ "$fstype" != "vfat" ]] || [[ -n "$partlabel" && ! "$partlabel" =~ [Ee][Ff][Ii] ]]; then
+  echo "[esp-validate] WARNING: $ESP_DEV does not appear to be an EFI System Partition (FSTYPE=$fstype PARTLABEL=$partlabel)" >&2
+fi


### PR DESCRIPTION
## Summary
- add a curl-friendly bootstrap script to run install, ZBM setup, and validation
- warn if ESP argument is questionable via `esp-validate`
- document one-shot usage in README

## Testing
- `bash -n all-in-one.sh`
- `bash -n esp-validate`
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y shellcheck` *(fails: Unable to locate package)*


------
https://chatgpt.com/codex/tasks/task_e_68a3af48add88323ad687c61e617c41a