### PR TITLE
fix: use anonymous cloning in all-in-one script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Opinionated ZFS setup for CachyOS providing ZFSBootMenu boot environments, autom
 ## Quick start
 Run everything in one shot (replace `/dev/nvme0n1p1` with your ESP device):
 ```bash
-curl -fsSL https://raw.githubusercontent.com/CachyOS/cachyos-zfs-setup/main/all-in-one.sh | sudo bash -s -- /dev/nvme0n1p1
+curl -fsSL https://raw.githubusercontent.com/polkamaphone/cachyos-zfs-setup/main/all-in-one.sh | sudo bash -s -- /dev/nvme0n1p1
 ```
 The script clones this repository, installs helpers, configures ZFSBootMenu and runs validation. If the ESP device looks suspicious, it will warn before proceeding.
 

--- a/all-in-one.sh
+++ b/all-in-one.sh
@@ -6,19 +6,19 @@
 #   curl -fsSL https://raw.githubusercontent.com/<owner>/cachyos-zfs-setup/main/all-in-one.sh | sudo bash -s -- [ESP_DEVICE]
 #
 # Environment variables:
-#   REPO_URL  - Git repository to clone (default: https://github.com/CachyOS/cachyos-zfs-setup.git)
+#   REPO_URL  - Git repository to clone (default: https://github.com/polkamaphone/cachyos-zfs-setup.git)
 #   BRANCH    - Branch to checkout (default: main)
 #   WORKDIR   - Directory to clone into (default: /tmp/cachyos-zfs-setup)
 
 set -euo pipefail
 
-REPO_URL="${REPO_URL:-https://github.com/CachyOS/cachyos-zfs-setup.git}"
+REPO_URL="${REPO_URL:-https://github.com/polkamaphone/cachyos-zfs-setup.git}"
 BRANCH="${BRANCH:-main}"
 WORKDIR="${WORKDIR:-/tmp/cachyos-zfs-setup}"
 
 # Fresh clone
 rm -rf "$WORKDIR"
-git clone --depth 1 --branch "$BRANCH" "$REPO_URL" "$WORKDIR"
+GIT_TERMINAL_PROMPT=0 git clone --depth 1 --branch "$BRANCH" "$REPO_URL" "$WORKDIR"
 cd "$WORKDIR"
 
 # Warn if ESP argument looks suspicious


### PR DESCRIPTION
## Summary
- point default clone URL to polkamaphone/cachyos-zfs-setup
- prevent git from prompting for credentials during clone
- document new one-liner install URL

## Testing
- `bash -n all-in-one.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a3b89dcb7c8323b1fc07b298fc4c3a