### PR TITLE
Prompt for confirmation on ESP validation warnings

### DIFF
--- a/esp-validate
+++ b/esp-validate
@@ -6,23 +6,32 @@ set -euo pipefail
 
 ESP_DEV="${1:-}"
 
+confirm_or_exit() {
+  local reason="$1"
+  echo "[esp-validate] WARNING: $reason" >&2
+  echo "[esp-validate] Proceeding may leave your system unbootable or cause data loss." >&2
+  read -rp "[esp-validate] Type 'yes' to continue or anything else to abort: " resp
+  if [[ "$resp" != "yes" ]]; then
+    echo "[esp-validate] Aborting at user request." >&2
+    exit 1
+  fi
+}
+
 if [[ -z "$ESP_DEV" ]]; then
   echo "[esp-validate] No ESP device specified; skipping validation" >&2
   exit 0
 fi
 
 if [[ ! -e "$ESP_DEV" ]]; then
-  echo "[esp-validate] WARNING: $ESP_DEV does not exist" >&2
-  exit 0
+  confirm_or_exit "$ESP_DEV does not exist."
 fi
 
 if [[ ! -b "$ESP_DEV" ]]; then
-  echo "[esp-validate] WARNING: $ESP_DEV is not a block device" >&2
-  exit 0
+  confirm_or_exit "$ESP_DEV is not a block device."
 fi
 
 fstype=$(lsblk -no FSTYPE "$ESP_DEV" 2>/dev/null || true)
 partlabel=$(lsblk -no PARTLABEL "$ESP_DEV" 2>/dev/null || true)
 if [[ "$fstype" != "vfat" ]] || [[ -n "$partlabel" && ! "$partlabel" =~ [Ee][Ff][Ii] ]]; then
-  echo "[esp-validate] WARNING: $ESP_DEV does not appear to be an EFI System Partition (FSTYPE=$fstype PARTLABEL=$partlabel)" >&2
+  confirm_or_exit "$ESP_DEV does not appear to be an EFI System Partition (FSTYPE=$fstype PARTLABEL=$partlabel)."
 fi


### PR DESCRIPTION
## Summary
- add reusable confirmation helper to esp-validate
- block install until user confirms ESP warnings and show full warning details

## Testing
- `bash -n esp-validate`
- `shellcheck esp-validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bbe49164832392a4eb7f30a27b80